### PR TITLE
GitHubリポジトリ検索機能の追加

### DIFF
--- a/GitRestApiApp.xcodeproj/project.pbxproj
+++ b/GitRestApiApp.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		1B0A9F0A276891CF00A53B6D /* GitRestApiAppApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B0A9F09276891CF00A53B6D /* GitRestApiAppApp.swift */; };
+		1B0A9F0A276891CF00A53B6D /* GitRestApiApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B0A9F09276891CF00A53B6D /* GitRestApiApp.swift */; };
 		1B0A9F0C276891CF00A53B6D /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B0A9F0B276891CF00A53B6D /* ContentView.swift */; };
 		1B0A9F0E276891D300A53B6D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1B0A9F0D276891D300A53B6D /* Assets.xcassets */; };
 		1B0A9F11276891D300A53B6D /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1B0A9F10276891D300A53B6D /* Preview Assets.xcassets */; };
@@ -16,6 +16,7 @@
 		1B0A9F20276891D400A53B6D /* GitRestApiAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B0A9F1F276891D400A53B6D /* GitRestApiAppTests.swift */; };
 		1B0A9F2A276891D400A53B6D /* GitRestApiAppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B0A9F29276891D400A53B6D /* GitRestApiAppUITests.swift */; };
 		1B0A9F2C276891D400A53B6D /* GitRestApiAppUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B0A9F2B276891D400A53B6D /* GitRestApiAppUITestsLaunchTests.swift */; };
+		1B0A9F392768976400A53B6D /* ResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B0A9F382768976400A53B6D /* ResultView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -37,7 +38,7 @@
 
 /* Begin PBXFileReference section */
 		1B0A9F06276891CF00A53B6D /* GitRestApiApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GitRestApiApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		1B0A9F09276891CF00A53B6D /* GitRestApiAppApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRestApiAppApp.swift; sourceTree = "<group>"; };
+		1B0A9F09276891CF00A53B6D /* GitRestApiApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRestApiApp.swift; sourceTree = "<group>"; };
 		1B0A9F0B276891CF00A53B6D /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		1B0A9F0D276891D300A53B6D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		1B0A9F10276891D300A53B6D /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
@@ -48,6 +49,7 @@
 		1B0A9F25276891D400A53B6D /* GitRestApiAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GitRestApiAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		1B0A9F29276891D400A53B6D /* GitRestApiAppUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRestApiAppUITests.swift; sourceTree = "<group>"; };
 		1B0A9F2B276891D400A53B6D /* GitRestApiAppUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRestApiAppUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		1B0A9F382768976400A53B6D /* ResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -98,8 +100,9 @@
 		1B0A9F08276891CF00A53B6D /* GitRestApiApp */ = {
 			isa = PBXGroup;
 			children = (
-				1B0A9F09276891CF00A53B6D /* GitRestApiAppApp.swift */,
+				1B0A9F09276891CF00A53B6D /* GitRestApiApp.swift */,
 				1B0A9F0B276891CF00A53B6D /* ContentView.swift */,
+				1B0A9F382768976400A53B6D /* ResultView.swift */,
 				1B0A9F0D276891D300A53B6D /* Assets.xcassets */,
 				1B0A9F12276891D300A53B6D /* Persistence.swift */,
 				1B0A9F14276891D300A53B6D /* GitRestApiApp.xcdatamodeld */,
@@ -265,7 +268,8 @@
 			files = (
 				1B0A9F13276891D300A53B6D /* Persistence.swift in Sources */,
 				1B0A9F0C276891CF00A53B6D /* ContentView.swift in Sources */,
-				1B0A9F0A276891CF00A53B6D /* GitRestApiAppApp.swift in Sources */,
+				1B0A9F392768976400A53B6D /* ResultView.swift in Sources */,
+				1B0A9F0A276891CF00A53B6D /* GitRestApiApp.swift in Sources */,
 				1B0A9F16276891D300A53B6D /* GitRestApiApp.xcdatamodeld in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/GitRestApiApp.xcodeproj/project.pbxproj
+++ b/GitRestApiApp.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		1B0A9F2A276891D400A53B6D /* GitRestApiAppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B0A9F29276891D400A53B6D /* GitRestApiAppUITests.swift */; };
 		1B0A9F2C276891D400A53B6D /* GitRestApiAppUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B0A9F2B276891D400A53B6D /* GitRestApiAppUITestsLaunchTests.swift */; };
 		1B0A9F392768976400A53B6D /* ResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B0A9F382768976400A53B6D /* ResultView.swift */; };
+		1B0A9F3B2768AB1B00A53B6D /* GitApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B0A9F3A2768AB1B00A53B6D /* GitApi.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -50,6 +51,7 @@
 		1B0A9F29276891D400A53B6D /* GitRestApiAppUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRestApiAppUITests.swift; sourceTree = "<group>"; };
 		1B0A9F2B276891D400A53B6D /* GitRestApiAppUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRestApiAppUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		1B0A9F382768976400A53B6D /* ResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultView.swift; sourceTree = "<group>"; };
+		1B0A9F3A2768AB1B00A53B6D /* GitApi.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitApi.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -103,6 +105,7 @@
 				1B0A9F09276891CF00A53B6D /* GitRestApiApp.swift */,
 				1B0A9F0B276891CF00A53B6D /* ContentView.swift */,
 				1B0A9F382768976400A53B6D /* ResultView.swift */,
+				1B0A9F3A2768AB1B00A53B6D /* GitApi.swift */,
 				1B0A9F0D276891D300A53B6D /* Assets.xcassets */,
 				1B0A9F12276891D300A53B6D /* Persistence.swift */,
 				1B0A9F14276891D300A53B6D /* GitRestApiApp.xcdatamodeld */,
@@ -271,6 +274,7 @@
 				1B0A9F392768976400A53B6D /* ResultView.swift in Sources */,
 				1B0A9F0A276891CF00A53B6D /* GitRestApiApp.swift in Sources */,
 				1B0A9F16276891D300A53B6D /* GitRestApiApp.xcdatamodeld in Sources */,
+				1B0A9F3B2768AB1B00A53B6D /* GitApi.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/GitRestApiApp/ContentView.swift
+++ b/GitRestApiApp/ContentView.swift
@@ -8,81 +8,33 @@
 import SwiftUI
 import CoreData
 
+
 struct ContentView: View {
-    @Environment(\.managedObjectContext) private var viewContext
-
-    @FetchRequest(
-        sortDescriptors: [NSSortDescriptor(keyPath: \Item.timestamp, ascending: true)],
-        animation: .default)
-    private var items: FetchedResults<Item>
-
+    @State private var query = ""
+    
     var body: some View {
         NavigationView {
-            List {
-                ForEach(items) { item in
-                    NavigationLink {
-                        Text("Item at \(item.timestamp!, formatter: itemFormatter)")
-                    } label: {
-                        Text(item.timestamp!, formatter: itemFormatter)
-                    }
+            VStack {
+                Spacer()
+                TextField("query", text: $query)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .padding()
+                    .submitLabel(.done)
+                
+                NavigationLink(destination: ResultView(query: query)) {
+                    Text("search")
                 }
-                .onDelete(perform: deleteItems)
-            }
-            .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    EditButton()
-                }
-                ToolbarItem {
-                    Button(action: addItem) {
-                        Label("Add Item", systemImage: "plus")
-                    }
-                }
-            }
-            Text("Select an item")
+                
+                Spacer()
+            }.navigationTitle("GitRepoSearch")
         }
+        
     }
-
-    private func addItem() {
-        withAnimation {
-            let newItem = Item(context: viewContext)
-            newItem.timestamp = Date()
-
-            do {
-                try viewContext.save()
-            } catch {
-                // Replace this implementation with code to handle the error appropriately.
-                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
-                let nsError = error as NSError
-                fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
-            }
-        }
-    }
-
-    private func deleteItems(offsets: IndexSet) {
-        withAnimation {
-            offsets.map { items[$0] }.forEach(viewContext.delete)
-
-            do {
-                try viewContext.save()
-            } catch {
-                // Replace this implementation with code to handle the error appropriately.
-                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
-                let nsError = error as NSError
-                fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
-            }
-        }
-    }
+    
 }
-
-private let itemFormatter: DateFormatter = {
-    let formatter = DateFormatter()
-    formatter.dateStyle = .short
-    formatter.timeStyle = .medium
-    return formatter
-}()
 
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
-        ContentView().environment(\.managedObjectContext, PersistenceController.preview.container.viewContext)
+        ContentView()
     }
 }

--- a/GitRestApiApp/ContentView.swift
+++ b/GitRestApiApp/ContentView.swift
@@ -10,6 +10,7 @@ import CoreData
 
 
 struct ContentView: View {
+    /// 検索クエリ
     @State private var query = ""
     
     var body: some View {

--- a/GitRestApiApp/GitApi.swift
+++ b/GitRestApiApp/GitApi.swift
@@ -1,0 +1,40 @@
+//
+//  GitApi.swift
+//  GitRestApiApp
+//
+//  Created by Ryusei Wada on 2021/12/14.
+//
+
+import Foundation
+import Combine
+
+struct API {
+    static func search(page: Int, perPage: Int, query: String) -> AnyPublisher<[Repository], Error> {
+        let url = URL(string: "https://api.github.com/search/repositories?q=\(query)&sort=stars&page=\(page)&per_page=\(perPage)")!
+        return URLSession.shared
+            .dataTaskPublisher(for: url)
+            .tryMap { try JSONDecoder().decode(Result.self, from: $0.data).items }
+            .receive(on: DispatchQueue.main)
+            .eraseToAnyPublisher()
+    }
+}
+
+struct Result: Codable {
+    let items: [Repository]
+}
+
+struct Repository: Codable, Identifiable, Equatable {
+    let id: Int
+    let name: String
+    let description: String?
+    let url: String
+    let stargazersCount: Int
+    
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case description
+        case url = "html_url"
+        case stargazersCount = "stargazers_count"
+    }
+}

--- a/GitRestApiApp/GitApi.swift
+++ b/GitRestApiApp/GitApi.swift
@@ -23,6 +23,15 @@ struct Result: Codable {
     let items: [Repository]
 }
 
+/// リポジトリ情報格納用の構造体
+///
+/// {
+/// id,
+/// name,
+/// description,
+/// url,
+/// stargazersCount
+/// }
 struct Repository: Codable, Identifiable, Equatable {
     let id: Int
     let name: String

--- a/GitRestApiApp/GitRestApiApp.swift
+++ b/GitRestApiApp/GitRestApiApp.swift
@@ -1,5 +1,5 @@
 //
-//  GitRestApiAppApp.swift
+//  GitRestApiApp.swift
 //  GitRestApiApp
 //
 //  Created by Ryusei Wada on 2021/12/14.

--- a/GitRestApiApp/ResultView.swift
+++ b/GitRestApiApp/ResultView.swift
@@ -8,37 +8,6 @@
 import SwiftUI
 import Combine
 
-enum API {
-    static func search(page: Int, perPage: Int, query: String) -> AnyPublisher<[Repository], Error> {
-        let url = URL(string: "https://api.github.com/search/repositories?q=\(query)&sort=stars&page=\(page)&per_page=\(perPage)")!
-        return URLSession.shared
-            .dataTaskPublisher(for: url)
-            .tryMap { try JSONDecoder().decode(Result.self, from: $0.data).items }
-            .receive(on: DispatchQueue.main)
-            .eraseToAnyPublisher()
-    }
-}
-
-struct Result: Codable {
-    let items: [Repository]
-}
-
-struct Repository: Codable, Identifiable, Equatable {
-    let id: Int
-    let name: String
-    let description: String?
-    let url: String
-    let stargazersCount: Int
-    
-    enum CodingKeys: String, CodingKey {
-        case id
-        case name
-        case description
-        case url = "html_url"
-        case stargazersCount = "stargazers_count"
-    }
-}
-
 struct ResultView: View {
     @State private var repositories: [Repository] = []
     @State private var subscriptions = Set<AnyCancellable>()
@@ -51,25 +20,29 @@ struct ResultView: View {
             List(repositories) { repository in
                 VStack(alignment: .leading) {
                     Text(repository.name)
-                        .font(Font.system(size: 24).bold())
+                        .font(.title2)
+                        .fontWeight(.bold)
                         .foregroundColor(Color.pink)
                         
                     Text("Description")
-                        .fontWeight(.bold)
+                        .font(.headline)
                         .italic()
                     Text(repository.description ?? "")
+                        .font(.body)
                     Text("URL")
-                        .fontWeight(.bold)
+                        .font(.headline)
                         .italic()
                     Text(repository.url)
+                        .font(.body)
                     Text("⭐️")
-                        .fontWeight(.bold)
+                        .font(.headline)
                         .italic()
                     Text(" \(repository.stargazersCount)")
+                        .font(.body)
                 }
             }
         }
-        .navigationBarTitle("search query : \(query)")
+        .navigationBarTitle("query : \(query)")
         .onAppear {
             API.search(page: 1, perPage: 30, query: query)
                 .sink(receiveCompletion: { completion in

--- a/GitRestApiApp/ResultView.swift
+++ b/GitRestApiApp/ResultView.swift
@@ -1,0 +1,101 @@
+//
+//  ResultView.swift
+//  GitRestApiApp
+//
+//  Created by Ryusei Wada on 2021/12/14.
+//
+
+import SwiftUI
+import Combine
+
+enum API {
+    static func search(page: Int, perPage: Int, query: String) -> AnyPublisher<[Repository], Error> {
+        let url = URL(string: "https://api.github.com/search/repositories?q=\(query)&sort=stars&page=\(page)&per_page=\(perPage)")!
+        return URLSession.shared
+            .dataTaskPublisher(for: url)
+            .tryMap { try JSONDecoder().decode(Result.self, from: $0.data).items }
+            .receive(on: DispatchQueue.main)
+            .eraseToAnyPublisher()
+    }
+}
+
+struct Result: Codable {
+    let items: [Repository]
+}
+
+struct Repository: Codable, Identifiable, Equatable {
+    let id: Int
+    let name: String
+    let description: String?
+    let url: String
+    let stargazersCount: Int
+    
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case description
+        case url = "html_url"
+        case stargazersCount = "stargazers_count"
+    }
+}
+
+struct ResultView: View {
+    @State private var repositories: [Repository] = []
+    @State private var subscriptions = Set<AnyCancellable>()
+    @State private var showingAlert = false
+    @State private var errorMessage = ""
+    let query : String
+    
+    var body: some View {
+        VStack {
+            List(repositories) { repository in
+                VStack(alignment: .leading) {
+                    Text(repository.name)
+                        .font(Font.system(size: 24).bold())
+                        .foregroundColor(Color.pink)
+                        
+                    Text("Description")
+                        .fontWeight(.bold)
+                        .italic()
+                    Text(repository.description ?? "")
+                    Text("URL")
+                        .fontWeight(.bold)
+                        .italic()
+                    Text(repository.url)
+                    Text("⭐️")
+                        .fontWeight(.bold)
+                        .italic()
+                    Text(" \(repository.stargazersCount)")
+                }
+            }
+        }
+        .navigationBarTitle("search query : \(query)")
+        .onAppear {
+            API.search(page: 1, perPage: 30, query: query)
+                .sink(receiveCompletion: { completion in
+                    switch completion {
+                    case .finished:
+                        break
+                    case let .failure(error):
+                        self.showingAlert = true
+                        self.errorMessage = error.localizedDescription
+                    }
+                }, receiveValue: { repositories in
+                    self.repositories = repositories
+                })
+                .store(in: &self.subscriptions)
+        }
+        .alert(isPresented: self.$showingAlert) {
+            Alert(
+                title: Text("Error"),
+                message: Text(self.errorMessage),
+                dismissButton: .default(Text("Close")))
+        }
+    }
+}
+
+struct ResultView_Previews: PreviewProvider {
+    static var previews: some View {
+        ResultView(query: "swift")
+    }
+}

--- a/GitRestApiApp/ResultView.swift
+++ b/GitRestApiApp/ResultView.swift
@@ -48,9 +48,10 @@ struct ResultView: View {
         }
         .navigationBarTitle("query : \(query)")
         .onAppear {
-            // search() -> AnyPublisher<[Repository],Error>
+            /// 取得したリポジトリ情報のPublisher
             let publisher = API.search(page: 1, perPage: 30, query: query)
 
+            /// リポジトリ情報をSubscribeしてrepositoriesに格納するSubscriber
             let subscriber = Subscribers.Sink<[Repository], Error>(
                 receiveCompletion: { completion in
                     switch completion {
@@ -66,8 +67,10 @@ struct ResultView: View {
                     self.repositories = repositories
                 })
             
+            // subscribeをキャンセルするためのトークンをstore
             subscriber.store(in: &self.cancellables)
             
+            // subscribe登録
             publisher.subscribe(subscriber)
         }
         .alert(isPresented: self.$showingAlert) {


### PR DESCRIPTION
## チケットへのリンク

なし

## やったこと

* 以下の機能を作成
  * TextFieldから文字列を取得し、検索結果の表示画面へ渡す機能
  * 前画面から受け取った文字列をクエリとして用いてGitHubのAPIを叩き、リポジトリの検索結果を受け取る機能
  * 受け取った検索結果をListで表示する機能

## やらないこと

* 取得する検索結果のカスタマイズ（スター順上位30個を取得で固定）

## できるようになること（ユーザ目線）

* クエリを入力し，「search」ボタンを押すと，遷移先の結果表示画面でGitHubのリポジトリの検索結果が閲覧できる

## できなくなること（ユーザ目線）

なし

## その他